### PR TITLE
Upping CM_GRID bounds to cover all world geo

### DIFF
--- a/tools/remap/source/bspfile_titanfall.cpp
+++ b/tools/remap/source/bspfile_titanfall.cpp
@@ -495,10 +495,10 @@ void Titanfall::EmitCollisionGrid() {
 	
 	Titanfall::CMGrid_t& grid = Titanfall::Bsp::cmGrid.emplace_back();
 	grid.scale = scale;
-	grid.xOffset = floor( Titanfall::Bsp::models[0].minmax.mins.x() / grid.scale );
-	grid.yOffset = floor( Titanfall::Bsp::models[0].minmax.mins.y() / grid.scale );
-	grid.xCount = ceil( size.x() / grid.scale ) + 1;
-	grid.yCount = ceil( size.y() / grid.scale ) + 1;
+	grid.xOffset = floor( Titanfall::Bsp::models[0].minmax.mins.x() / grid.scale ) - 1;
+	grid.yOffset = floor( Titanfall::Bsp::models[0].minmax.mins.y() / grid.scale ) - 1;
+	grid.xCount = ceil( size.x() / grid.scale ) + 2;
+	grid.yCount = ceil( size.y() / grid.scale ) + 2;
 	grid.unk2 = Titanfall::Bsp::cmBrushes.size();
 	grid.brushSidePlaneOffset = 0;
 


### PR DESCRIPTION
Was missing world min.x & mins.y edges

Already kinda explained this in discord, basically grid bounds was off by one.
Diagrams:
```python
Grid(scale=256.0, offset=<MappedArray (x: 0, y: -1)>, count=<MappedArray (x: 5, y: 3)>, unknown=(21, 0))
```
![firing_range_grid_cells](https://user-images.githubusercontent.com/36507175/200106154-7680211d-90fb-4126-9c07-189879f2c0f7.png)
![firing_range_grid_cells_ideal](https://user-images.githubusercontent.com/36507175/200106158-440dcf64-a73b-4d03-aa3d-fe90cff02802.png)
```python
Grid(scale=256.0, offset=<MappedArray (x: -1, y: -1)>, count=<MappedArray (x: 2, y: 2)>, unknown=(6, 0))
```
![r1_lobby_grid_cell_bounds](https://user-images.githubusercontent.com/36507175/200106162-a515384f-77a5-43fa-97ba-1ae99a776c3e.png)
